### PR TITLE
add ItalianGroupMealsUseCaseTest with comprehensive test coverage

### DIFF
--- a/src/main/kotlin/data/RecipesRepositoryCsvImpl.kt
+++ b/src/main/kotlin/data/RecipesRepositoryCsvImpl.kt
@@ -7,7 +7,7 @@ class RecipesRepositoryCsvImpl(
     private val csvReader: CsvReader,
     private val csvParser: CsvParser
 ): RecipesRepository {
-    val recipes: MutableList<Recipe> = mutableListOf()
+    private val recipes: MutableList<Recipe> = mutableListOf()
 
     override fun getAllRecipes(): List<Recipe> {
         return recipes.ifEmpty {

--- a/src/main/kotlin/data/RecipesRepositoryCsvImpl.kt
+++ b/src/main/kotlin/data/RecipesRepositoryCsvImpl.kt
@@ -7,8 +7,12 @@ class RecipesRepositoryCsvImpl(
     private val csvReader: CsvReader,
     private val csvParser: CsvParser
 ): RecipesRepository {
+    val recipes: MutableList<Recipe> = mutableListOf()
+
     override fun getAllRecipes(): List<Recipe> {
-        val lines = csvReader.readCsv().drop(1)
-        return csvParser.parseCsvFile(lines).filterNotNull()
+        return recipes.ifEmpty {
+            val lines = csvReader.readCsv().drop(1)
+            return csvParser.parseCsvFile(lines).filterNotNull()
+        }
     }
 }

--- a/src/main/kotlin/logic/use_case/ItalianGroupMealsUseCase.kt
+++ b/src/main/kotlin/logic/use_case/ItalianGroupMealsUseCase.kt
@@ -1,5 +1,6 @@
 package org.example.logic.use_case
 
+import org.example.error.RecipeNotFoundException
 import org.example.logic.RecipesRepository
 import org.example.model.Recipe
 
@@ -7,11 +8,14 @@ class ItalianGroupMealsUseCase(
     private val repository: RecipesRepository
 ) {
     fun getItalianGroupMeals(): List<Recipe> {
-        return repository.getAllRecipes()
+        val result =  repository.getAllRecipes()
             .filter { recipe ->
                 val tags = recipe.tags?.map { it.replace("'", "").lowercase().trim() } ?: emptyList()
                 TAG_ITALIAN in tags && TAG_LARGE_GROUPS in tags
             }
+        return result.ifEmpty {
+            throw RecipeNotFoundException("No italian group meals")
+        }
     }
     companion object {
         private const val TAG_ITALIAN = "italian"

--- a/src/main/kotlin/model/Recipe.kt
+++ b/src/main/kotlin/model/Recipe.kt
@@ -3,18 +3,18 @@ package org.example.model
 import java.time.LocalDate
 
 data class Recipe(
-    val name: String?,
-    val id: String?,
-    val minutes: Int?,
-    val contributorId: String?,
-    val submittedDate: LocalDate?,
-    val tags: List<String>?,
-    val nutrition: Nutrition?,
-    val numberOfSteps: Int?,
-    val steps: List<String>?,
-    val description: String?,
-    val ingredients: List<String>?,
-    val numberOfIngredients: Int?
+    val name: String? = null,
+    val id: String? = null,
+    val minutes: Int? = null,
+    val contributorId: String? = null,
+    val submittedDate: LocalDate? = null,
+    val tags: List<String>? = null,
+    val nutrition: Nutrition? = null,
+    val numberOfSteps: Int? = null,
+    val steps: List<String>? = null,
+    val description: String? = null,
+    val ingredients: List<String>? = null,
+    val numberOfIngredients: Int? = null
 )
  fun Recipe.isComplete(): Boolean {
     return ingredients != null &&

--- a/src/test/kotlin/logic/use_case/ItalianGroupMealsUseCaseTest.kt
+++ b/src/test/kotlin/logic/use_case/ItalianGroupMealsUseCaseTest.kt
@@ -3,11 +3,13 @@ package logic.use_case
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
+import org.example.error.RecipeNotFoundException
 import org.example.logic.RecipesRepository
 import org.example.logic.use_case.ItalianGroupMealsUseCase
 import org.example.model.Recipe
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.assertThrows
 
 class ItalianGroupMealsUseCaseTest {
 
@@ -41,19 +43,18 @@ class ItalianGroupMealsUseCaseTest {
     }
 
     @Test
-    fun `should return empty list when there are no recipes`() {
+    fun `should throw RecipeNotFoundException when there are no recipes`() {
         // Given
         every { recipesRepository.getAllRecipes() } returns emptyList()
 
-        // when
-        val result = italianGroupMealsUseCase.getItalianGroupMeals()
-
-        // Then
-        assertThat(result).isEmpty()
+        // when && Then
+        assertThrows<RecipeNotFoundException> {
+            italianGroupMealsUseCase.getItalianGroupMeals()
+        }
     }
 
     @Test
-    fun `should return empty list when no recipes have both italian and for-large-groups tags`() {
+    fun `should throw RecipeNotFoundException when no recipes have both italian and for-large-groups tags`() {
         // Given
         val recipes = listOf(
             Recipe(name = "gaza recipes", tags = listOf("for-large-groups", "iraqi", "gaza")),
@@ -62,11 +63,10 @@ class ItalianGroupMealsUseCaseTest {
         )
         every { recipesRepository.getAllRecipes() } returns recipes
 
-        // when
-        val result = italianGroupMealsUseCase.getItalianGroupMeals()
-
-        // Then
-        assertThat(result).isEmpty()
+        // when && Then
+        assertThrows<RecipeNotFoundException> {
+            italianGroupMealsUseCase.getItalianGroupMeals()
+        }
     }
 
     @Test

--- a/src/test/kotlin/logic/use_case/ItalianGroupMealsUseCaseTest.kt
+++ b/src/test/kotlin/logic/use_case/ItalianGroupMealsUseCaseTest.kt
@@ -1,0 +1,131 @@
+package logic.use_case
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import org.example.logic.RecipesRepository
+import org.example.logic.use_case.ItalianGroupMealsUseCase
+import org.example.model.Recipe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.BeforeEach
+
+class ItalianGroupMealsUseCaseTest {
+
+    private lateinit var recipesRepository: RecipesRepository
+    private lateinit var italianGroupMealsUseCase: ItalianGroupMealsUseCase
+
+    @BeforeEach
+    fun setup() {
+        this.recipesRepository = mockk(relaxed = true)
+        this.italianGroupMealsUseCase = ItalianGroupMealsUseCase(this.recipesRepository)
+    }
+
+    @Test
+    fun `should return only italian recipes with both italian and large groups tags`() {
+        // Given
+        val recipes = listOf(
+            Recipe(name = "gaza recipes", tags = listOf("italians", "gaza")),
+            Recipe(name = "italian recipes", tags = listOf("italian", "for-large-groups", "gaza")),
+            Recipe(name = "italian recipes 2", tags = listOf("italian", "for-large-groups", "palestine")),
+            Recipe(name = "iraqi recipes", tags = listOf("iraqi")),
+        )
+        every { recipesRepository.getAllRecipes() } returns recipes
+
+        // when
+        val result = italianGroupMealsUseCase.getItalianGroupMeals()
+
+        // Then
+        assertThat(result).containsExactly(
+            recipes[1], recipes[2]
+        )
+    }
+
+    @Test
+    fun `should return empty list when there are no recipes`() {
+        // Given
+        every { recipesRepository.getAllRecipes() } returns emptyList()
+
+        // when
+        val result = italianGroupMealsUseCase.getItalianGroupMeals()
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should return empty list when no recipes have both italian and for-large-groups tags`() {
+        // Given
+        val recipes = listOf(
+            Recipe(name = "gaza recipes", tags = listOf("for-large-groups", "iraqi", "gaza")),
+            Recipe(name = "italian recipes", tags = listOf("italian", "iraqi", "gaza")),
+            Recipe(name = "iraqi recipes", tags = listOf("iraqi")),
+        )
+        every { recipesRepository.getAllRecipes() } returns recipes
+
+        // when
+        val result = italianGroupMealsUseCase.getItalianGroupMeals()
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should return only italian recipes when handle case-insensitive tags`() {
+        // Given
+        val recipes = listOf(
+            Recipe(name = "gaza recipes", tags = listOf("italians", "gaza")),
+            Recipe(name = "italian recipes 1", tags = listOf("ITALIAN", "for-large-groups", "gaza")),
+            Recipe(name = "italian recipes 2", tags = listOf("italian", "FOR-LARGE-GROUPS", "palestine")),
+            Recipe(name = "italian recipes 3", tags = listOf("Italian", "For-large-groups", "palestine")),
+            Recipe(name = "iraqi recipes", tags = listOf("iraqi")),
+        )
+        every { recipesRepository.getAllRecipes() } returns recipes
+
+        // when
+        val result = italianGroupMealsUseCase.getItalianGroupMeals()
+
+        // Then
+        assertThat(result).containsExactly(
+            recipes[1], recipes[2], recipes[3]
+        )
+    }
+
+    @Test
+    fun `should return only italian recipes when have only quotation signal in tags`() {
+        // Given
+        val recipes = listOf(
+            Recipe(name = "gaza recipes", tags = listOf("italians", "gaza")),
+            Recipe(name = "italian recipes 1", tags = listOf("'ITALIAN'", "for-large-groups", "gaza")),
+            Recipe(name = "italian recipes 2", tags = listOf("#italian$", "FOR-LARGE-GROUPS", "palestine")),
+            Recipe(name = "italian recipes 3", tags = listOf("not-Italian'", "'For-large-groups'", "'palestine'")),
+            Recipe(name = "iraqi recipes", tags = listOf("iraqi")),
+        )
+        every { recipesRepository.getAllRecipes() } returns recipes
+
+        // when
+        val result = italianGroupMealsUseCase.getItalianGroupMeals()
+
+        // Then
+        assertThat(result).containsExactly(recipes[1])
+    }
+
+    @Test
+    fun `should return only italian recipes and handle null tags`() {
+        // Given
+        val recipes = listOf(
+            Recipe(name = "italian recipes", tags = null),
+            Recipe(name = "italian recipes 1", tags = listOf("'ITALIAN'", "for-large-groups", "gaza")),
+            Recipe(name = "iraqi recipes", tags = listOf("iraqi")),
+        )
+        every { recipesRepository.getAllRecipes() } returns recipes
+
+        // when
+        val result = italianGroupMealsUseCase.getItalianGroupMeals()
+
+        // Then
+        assertThat(result).containsExactly(
+            recipes[1],
+        )
+    }
+
+}


### PR DESCRIPTION
- Implement ItalianGroupMealsUseCase to filter recipes with both 'italian' and 'for-large-groups' tags
- Add extensive test cases covering:
  	- Basic filtering functionality
  	- Empty list scenarios
  	- Case-insensitive tag matching
 	- Special character handling in tags
 	- Null tag handling
- Use MockK for repository mocking in tests
- Include Truth assertions for clear test expectations